### PR TITLE
Ability to build crate in no-std environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,12 @@ categories = ["mathematics", "no-std", "game-development", "algorithms"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["std"]
+std = ["num-traits/std"]
+
 [dependencies]
-num-traits = "0.2.15"
+num-traits = { version = "0.2.15", default-features=false }
 
 [dev-dependencies]
 rand = "0.8.5"


### PR DESCRIPTION
I tried to use this crate in my ATMega firmware and encountered a build error in the `num-traits` crate. Since `map-range` doesn't depend on `std` and `num-traits` can be built without `std` requirement I think this PR may be useful in cases like mine.